### PR TITLE
fix: ignore private link state after creation

### DIFF
--- a/internal/cloudsdk/region.go
+++ b/internal/cloudsdk/region.go
@@ -421,16 +421,13 @@ func (c *RegionServiceClient) CreatePrivateLinkAwait(ctx context.Context, id uin
 	err = wait.Poll(ctx, func() (bool, error) {
 		link, err := c.GetPrivateLink(ctx, id, info.Id)
 		if err != nil {
+			if errors.Is(err, ErrPrivateLinkNotFound) {
+				return false, nil
+			}
 			return false, err
 		}
 		rtn = link
-		if link.Status == apigen_mgmt.ERROR {
-			return false, errors.Errorf("failed to create private link, id: %s, creation of privateLink fails and enters an ERROR state", info.Id)
-		}
-		if link.Status == apigen_mgmt.CREATED {
-			return true, nil
-		}
-		return false, nil
+		return true, nil
 	}, PollingPrivateLinkCreation)
 
 	if err != nil {


### PR DESCRIPTION
since the private link object is created in the control plane even though its state is ERROR, this should be reflected in the tf state. 