### PR TITLE
feat: `wait_for_ready` attribute for private link

### DIFF
--- a/docs/resources/privatelink.md
+++ b/docs/resources/privatelink.md
@@ -80,6 +80,10 @@ terraform import risingwavecloud_privatelink.test <privatelink_id>
 - `connection_name` (String) The name of the Private Link connection, just for display purpose.
 - `target` (String) The target of the Private Link connection. In AWS, it is the service name of the VPC endpoint service. In GCP, it is the service attachment in Private Service Connect.
 
+### Optional
+
+- `wait_for_ready` (Boolean) Whether to wait for the private link to be ready after creation. Default is false.
+
 ### Read-Only
 
 - `endpoint` (String) The endpoint of the Private Link to connect to. This has different format for different platforms.

--- a/internal/cloudsdk/cloudsdk.go
+++ b/internal/cloudsdk/cloudsdk.go
@@ -77,6 +77,9 @@ type CloudClientInterface interface {
 	// GetPrivateLink returns the private link and its cluster ID by the given connection name.
 	GetPrivateLinkByName(ctx context.Context, connectionName string) (*PrivateLinkInfo, error)
 
+	// CreatePrivateLink creates the private link and returns the private link.
+	CreatePrivateLink(ctx context.Context, clusterNsID uuid.UUID, req apigen_mgmt.PostPrivateLinkRequestBody) (*PrivateLinkInfo, error)
+
 	// CreatePrivateLinkAwait creates the private link and waits for the creation to complete.
 	CreatePrivateLinkAwait(ctx context.Context, clusterNsID uuid.UUID, req apigen_mgmt.PostPrivateLinkRequestBody) (*PrivateLinkInfo, error)
 
@@ -407,6 +410,21 @@ func (c *CloudClient) GetPrivateLink(ctx context.Context, privateLinkID uuid.UUI
 	}
 
 	return nil, errors.Wrapf(ErrPrivateLinkNotFound, "private link %s", privateLinkID.String())
+}
+
+func (c *CloudClient) CreatePrivateLink(ctx context.Context, clusterNsID uuid.UUID, req apigen_mgmt.PostPrivateLinkRequestBody) (*PrivateLinkInfo, error) {
+	info, rs, err := c.getClusterInfoAndRegionClient(ctx, clusterNsID)
+	if err != nil {
+		return nil, err
+	}
+	pl, err := rs.CreatePrivateLink(ctx, info.Id, req)
+	if err != nil {
+		return nil, err
+	}
+	return &PrivateLinkInfo{
+		ClusterNsID: info.NsId,
+		PrivateLink: pl,
+	}, nil
 }
 
 func (c *CloudClient) CreatePrivateLinkAwait(ctx context.Context, clusterNsID uuid.UUID, req apigen_mgmt.PostPrivateLinkRequestBody) (*PrivateLinkInfo, error) {

--- a/internal/cloudsdk/fake/fake.go
+++ b/internal/cloudsdk/fake/fake.go
@@ -358,7 +358,7 @@ func (acc *FakeCloudClient) GetPrivateLink(ctx context.Context, privateLinkID uu
 	return nil, errors.Wrapf(cloudsdk.ErrPrivateLinkNotFound, "private link %s not found", privateLinkID)
 }
 
-func (acc *FakeCloudClient) CreatePrivateLinkAwait(ctx context.Context, clusterNsID uuid.UUID, req apigen_mgmt.PostPrivateLinkRequestBody) (*cloudsdk.PrivateLinkInfo, error) {
+func (acc *FakeCloudClient) CreatePrivateLink(ctx context.Context, clusterNsID uuid.UUID, req apigen_mgmt.PostPrivateLinkRequestBody) (*cloudsdk.PrivateLinkInfo, error) {
 	debugFuncCaller()
 
 	c, err := state.GetClusterByNsID(clusterNsID)
@@ -382,6 +382,12 @@ func (acc *FakeCloudClient) CreatePrivateLinkAwait(ctx context.Context, clusterN
 		PrivateLink: pl,
 		ClusterNsID: clusterNsID,
 	}, nil
+}
+
+func (acc *FakeCloudClient) CreatePrivateLinkAwait(ctx context.Context, clusterNsID uuid.UUID, req apigen_mgmt.PostPrivateLinkRequestBody) (*cloudsdk.PrivateLinkInfo, error) {
+	debugFuncCaller()
+
+	return acc.CreatePrivateLink(ctx, clusterNsID, req)
 }
 
 func (acc *FakeCloudClient) DeletePrivateLinkAwait(ctx context.Context, clusterNsID uuid.UUID, privateLinkID uuid.UUID) error {

--- a/internal/cloudsdk/mock/cloudsdk_gen.go
+++ b/internal/cloudsdk/mock/cloudsdk_gen.go
@@ -67,6 +67,21 @@ func (mr *MockCloudClientInterfaceMockRecorder) CreateClusterAwait(arg0, arg1, a
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateClusterAwait", reflect.TypeOf((*MockCloudClientInterface)(nil).CreateClusterAwait), arg0, arg1, arg2)
 }
 
+// CreatePrivateLink mocks base method.
+func (m *MockCloudClientInterface) CreatePrivateLink(arg0 context.Context, arg1 uuid.UUID, arg2 apigen.PostPrivateLinkRequestBody) (*cloudsdk.PrivateLinkInfo, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreatePrivateLink", arg0, arg1, arg2)
+	ret0, _ := ret[0].(*cloudsdk.PrivateLinkInfo)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreatePrivateLink indicates an expected call of CreatePrivateLink.
+func (mr *MockCloudClientInterfaceMockRecorder) CreatePrivateLink(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreatePrivateLink", reflect.TypeOf((*MockCloudClientInterface)(nil).CreatePrivateLink), arg0, arg1, arg2)
+}
+
 // CreatePrivateLinkAwait mocks base method.
 func (m *MockCloudClientInterface) CreatePrivateLinkAwait(arg0 context.Context, arg1 uuid.UUID, arg2 apigen.PostPrivateLinkRequestBody) (*cloudsdk.PrivateLinkInfo, error) {
 	m.ctrl.T.Helper()

--- a/internal/cloudsdk/region.go
+++ b/internal/cloudsdk/region.go
@@ -429,6 +429,9 @@ func (c *RegionServiceClient) CreatePrivateLink(ctx context.Context, id uint64, 
 			return false, err
 		}
 		rtn = link
+		if link.Status == apigen_mgmt.CREATED {
+			return true, nil
+		}
 		return true, nil
 	}, PollingPrivateLinkCreation)
 	if err != nil {
@@ -460,7 +463,7 @@ func (c *RegionServiceClient) CreatePrivateLinkAwait(ctx context.Context, id uin
 			return false, err
 		}
 		rtn = link
-		if link.Status == apigen_mgmt.CREATED || link.Status == apigen_mgmt.ERROR {
+		if link.ConnectionState == apigen_mgmt.ACCEPTED {
 			return true, nil
 		}
 		return false, nil

--- a/internal/provider/acctest/provider_test.go
+++ b/internal/provider/acctest/provider_test.go
@@ -1,3 +1,6 @@
+//go:build !ut
+// +build !ut
+
 package acctest
 
 import (

--- a/internal/provider/resource_privatelink.go
+++ b/internal/provider/resource_privatelink.go
@@ -286,7 +286,7 @@ func (r *PrivateLinkResource) Delete(ctx context.Context, req resource.DeleteReq
 	if err := r.client.DeletePrivateLinkAwait(ctx, clusterNsID, privateLinkID); err != nil {
 		if errors.Is(err, wait.ErrWaitTimeout) {
 			resp.Diagnostics.AddError(
-				"Timeout waiting for privatelink to be deleted",
+				fmt.Sprintf("Timeout waiting for privatelink %s to be deleted", privateLinkID.String()),
 				err.Error(),
 			)
 			return

--- a/internal/provider/resource_privatelink.go
+++ b/internal/provider/resource_privatelink.go
@@ -153,14 +153,24 @@ func (r *PrivateLinkResource) Create(ctx context.Context, req resource.CreateReq
 			return
 		}
 	}
-
-	pl, err = r.client.CreatePrivateLinkAwait(ctx, nsID, apigen.PostPrivateLinkRequestBody{
-		ConnectionName: connectionName,
-		Target:         target,
-	})
-	if err != nil {
-		resp.Diagnostics.AddError("Create failed", err.Error())
-		return
+	if data.WaitForReady.ValueBool() {
+		pl, err = r.client.CreatePrivateLinkAwait(ctx, nsID, apigen.PostPrivateLinkRequestBody{
+			ConnectionName: connectionName,
+			Target:         target,
+		})
+		if err != nil {
+			resp.Diagnostics.AddError("Create failed", err.Error())
+			return
+		}
+	} else {
+		pl, err = r.client.CreatePrivateLink(ctx, nsID, apigen.PostPrivateLinkRequestBody{
+			ConnectionName: connectionName,
+			Target:         target,
+		})
+		if err != nil {
+			resp.Diagnostics.AddError("Create failed", err.Error())
+			return
+		}
 	}
 
 	tflog.Info(ctx, fmt.Sprintf("private link created, connection name: %s", connectionName))

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -1,0 +1,8 @@
+package utils
+
+func IfElse[T any](cond bool, v T, d T) T {
+	if cond {
+		return v
+	}
+	return d
+}


### PR DESCRIPTION
1. with `wait_for_ready` enabled, the provider will wait for the private link is ready for used.
2. wait `wait_for_ready` disabled (the default behavior), the provider simply creates a private link definition in the RisingWave Cloud without checking if it is functional.
