### PR TITLE
fix: support custom privatelink target in acc test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -102,5 +102,6 @@ jobs:
           RWC_API_SECRET: ${{ secrets.RWC_API_SECRET }}
           TEST_NAMESPACE: ${{ matrix.terraform }}
           RWC_MOCK: "1"
+          TEST_PRIVATE_LINK_TARGET: ${{ secrets.TEST_PRIVATE_LINK_TARGET }}
         run: go test -v -timeout 30m github.com/risingwavelabs/terraform-provider-risingwavecloud/internal/provider/acctest
         timeout-minutes: 20


### PR DESCRIPTION
use `TEST_PRIVATE_LINK_TARGET` to designate the private link target for the acceptance test