### PR TITLE
fix: cannot update cluster since clustername is not set

### DIFF
--- a/internal/cloudsdk/fake/fake.go
+++ b/internal/cloudsdk/fake/fake.go
@@ -87,6 +87,11 @@ func (acc *FakeCloudClient) IsTenantNameExist(ctx context.Context, region string
 func (acc *FakeCloudClient) CreateClusterAwait(ctx context.Context, region string, req apigen_mgmt.TenantRequestRequestBody) (*apigen_mgmt.Tenant, error) {
 	debugFuncCaller()
 
+	clusterName := req.ClusterName
+	if clusterName == nil {
+		clusterName = ptr.Ptr("default-control-plane")
+	}
+
 	r := state.GetRegionState(region)
 	t := &apigen_mgmt.Tenant{
 		Id:          uint64(len(r.GetClusters()) + 1),
@@ -98,7 +103,7 @@ func (acc *FakeCloudClient) CreateClusterAwait(ctx context.Context, region strin
 		Resources:   reqResouceToClusterResource(req.Resources),
 		NsId:        uuid.New(),
 		Tier:        *req.Tier,
-		ClusterName: req.ClusterName,
+		ClusterName: clusterName,
 	}
 	cluster := NewClusterState(t)
 	r.AddCluster(cluster)

--- a/internal/provider/resource_cluster.go
+++ b/internal/provider/resource_cluster.go
@@ -814,24 +814,35 @@ func (r *ClusterResource) Update(ctx context.Context, req resource.UpdateRequest
 	}
 
 	// immutable fields
-	if previous.ClusterName == nil && updated.ClusterName != nil {
+	if previous.Tier != updated.Tier {
 		resp.Diagnostics.AddError(
 			"Cannot update immutable field",
-			fmt.Sprintf("Cluster name cannot be changed, previous is not set, now is %s", *updated.ClusterName),
+			"Tier cannot be changed",
 		)
 	}
-	if previous.ClusterName != nil && updated.ClusterName == nil {
-		resp.Diagnostics.AddError(
-			"Cannot update immutable field",
-			fmt.Sprintf("Cluster name cannot be changed, previous is %s, now is not set", *previous.ClusterName),
-		)
+
+	// only check clusterName for BYOC
+	if previous.Tier == apigen_mgmt.BYOC {
+		if previous.ClusterName == nil && updated.ClusterName != nil {
+			resp.Diagnostics.AddError(
+				"Cannot update immutable field",
+				fmt.Sprintf("Cluster name cannot be changed, previous is not set, now is %s", *updated.ClusterName),
+			)
+		}
+		if previous.ClusterName != nil && updated.ClusterName == nil {
+			resp.Diagnostics.AddError(
+				"Cannot update immutable field",
+				fmt.Sprintf("Cluster name cannot be changed, previous is %s, now is not set", *previous.ClusterName),
+			)
+		}
+		if (previous.ClusterName != nil && updated.ClusterName != nil) && (*previous.ClusterName != *updated.ClusterName) {
+			resp.Diagnostics.AddError(
+				"Cannot update immutable field",
+				fmt.Sprintf("Cluster name cannot be changed, previous: %s, updated: %s", *previous.ClusterName, *updated.ClusterName),
+			)
+		}
 	}
-	if (previous.ClusterName != nil && updated.ClusterName != nil) && (*previous.ClusterName != *updated.ClusterName) {
-		resp.Diagnostics.AddError(
-			"Cannot update immutable field",
-			fmt.Sprintf("Cluster name cannot be changed, previous: %s, updated: %s", *previous.ClusterName, *updated.ClusterName),
-		)
-	}
+
 	if previous.TenantName != updated.TenantName {
 		resp.Diagnostics.AddError(
 			"Cannot update immutable field",


### PR DESCRIPTION
The update method will throw the error: "Cluster name cannot be changed, previous is default-control-plane, now is not set". 