### PR TITLE
feat: ignore computed IDs in plan

### DIFF
--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -120,7 +120,7 @@ Note that 1 RWU is equivalent to 1 vCPU and 4 GB of memory.
 ### Required
 
 - `name` (String) The name of the cluster.
-- `region` (String)
+- `region` (String) The region of the cluster.
 - `spec` (Attributes) The resource specification of the cluster (see [below for nested schema](#nestedatt--spec))
 
 ### Optional

--- a/internal/provider/resource_cluster.go
+++ b/internal/provider/resource_cluster.go
@@ -14,8 +14,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -246,9 +244,6 @@ func (r *ClusterResource) Schema(ctx context.Context, req resource.SchemaRequest
 				Optional:            true,
 				Default:             int64default.StaticInt64(1),
 				Computed:            true,
-				PlanModifiers: []planmodifier.Int64{
-					int64planmodifier.RequiresReplaceIfConfigured(),
-				},
 			},
 		},
 		MarkdownDescription: "The resource specification of the component",
@@ -409,9 +404,6 @@ func (r *ClusterResource) Schema(ctx context.Context, req resource.SchemaRequest
 									},
 								},
 								Computed: true,
-								PlanModifiers: []planmodifier.Object{
-									objectplanmodifier.RequiresReplaceIfConfigured(),
-								},
 							},
 						},
 						Required: true,

--- a/internal/provider/resource_cluster.go
+++ b/internal/provider/resource_cluster.go
@@ -14,7 +14,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
@@ -242,6 +246,9 @@ func (r *ClusterResource) Schema(ctx context.Context, req resource.SchemaRequest
 				Optional:            true,
 				Default:             int64default.StaticInt64(1),
 				Computed:            true,
+				PlanModifiers: []planmodifier.Int64{
+					int64planmodifier.RequiresReplaceIfConfigured(),
+				},
 			},
 		},
 		MarkdownDescription: "The resource specification of the component",
@@ -255,18 +262,28 @@ func (r *ClusterResource) Schema(ctx context.Context, req resource.SchemaRequest
 			"id": schema.StringAttribute{
 				MarkdownDescription: "The NsID (namespace id) of the cluster.",
 				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"encoded_id": schema.StringAttribute{
 				MarkdownDescription: "The encoded ID of the cluster. " +
 					"This field is only used in BYOC clusters.",
 				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"tier": schema.StringAttribute{
 				MarkdownDescription: "The tier of your RisingWave cluster. When creating a new cluster, the value is `standard`.",
 				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"region": schema.StringAttribute{
-				Required: true,
+				MarkdownDescription: "The region of the cluster.",
+				Required:            true,
 			},
 			"name": schema.StringAttribute{
 				MarkdownDescription: "The name of the cluster.",
@@ -292,6 +309,9 @@ func (r *ClusterResource) Schema(ctx context.Context, req resource.SchemaRequest
 						MarkdownDescription: "The encoded ID of the BYOC cluster. " +
 							"This field is only used in BYOC clusters.",
 						Computed: true,
+						PlanModifiers: []planmodifier.String{
+							stringplanmodifier.UseStateForUnknown(),
+						},
 					},
 				},
 			},
@@ -389,6 +409,9 @@ func (r *ClusterResource) Schema(ctx context.Context, req resource.SchemaRequest
 									},
 								},
 								Computed: true,
+								PlanModifiers: []planmodifier.Object{
+									objectplanmodifier.RequiresReplaceIfConfigured(),
+								},
 							},
 						},
 						Required: true,


### PR DESCRIPTION
Some computed attributes are unchanged after the resource is created, like IDs. Use plan modifier to ignore them during the plan phase. This will keep the terraform plan clean, so that the downstream resources depending on these attributes will not be affected.