### PR TITLE
fix: metaStoreEqual always returns false for non-nil metastores

### DIFF
--- a/internal/cloudsdk/fake/fake.go
+++ b/internal/cloudsdk/fake/fake.go
@@ -82,13 +82,22 @@ func (acc *FakeCloudClient) CreateClusterAwait(ctx context.Context, region strin
 	}
 
 	r := state.GetRegionState(region)
+	resources := reqResouceToClusterResource(req.Resources)
+	resources.MetaStore = &apigen_mgmtv2.TenantResourceMetaStore{
+		Type: apigen_mgmtv2.AwsRds,
+		AwsRds: &apigen_mgmtv2.MetaStoreAwsRds{
+			InstanceClass: "db.t3.micro",
+			SizeGb:        20,
+		},
+		Rwu: "2",
+	}
 	t := &apigen_mgmtv2.Tenant{
 		Id:          uint64(len(r.GetClusters()) + 1),
 		TenantName:  req.TenantName,
 		ImageTag:    *req.ImageTag,
 		Region:      region,
 		RwConfig:    *req.RwConfig,
-		Resources:   reqResouceToClusterResource(req.Resources),
+		Resources:   resources,
 		NsId:        uuid.New(),
 		Tier:        *req.Tier,
 		ClusterName: *clusterName,

--- a/internal/provider/resource_cluster.go
+++ b/internal/provider/resource_cluster.go
@@ -744,11 +744,7 @@ func metaStoreEqual(a, b *apigen_mgmtv2.TenantResourceMetaStore) bool {
 		return true
 	}
 
-	if a.Type != b.Type {
-		return false
-	}
-
-	return false
+	return a.Type == b.Type
 }
 
 func resourceEqual(a, b *apigen_mgmtv2.ComponentResource) bool {

--- a/internal/provider/resource_cluster_test.go
+++ b/internal/provider/resource_cluster_test.go
@@ -57,6 +57,59 @@ func createSimpleTestCluster(t *testing.T, name, region, imageTag string, tier a
 	}
 }
 
+func TestMetaStoreEqual(t *testing.T) {
+	tests := []struct {
+		name string
+		a    *apigen_mgmtv2.TenantResourceMetaStore
+		b    *apigen_mgmtv2.TenantResourceMetaStore
+		want bool
+	}{
+		{
+			name: "both nil",
+			a:    nil,
+			b:    nil,
+			want: true,
+		},
+		{
+			name: "a nil b non-nil",
+			a:    nil,
+			b:    &apigen_mgmtv2.TenantResourceMetaStore{Type: apigen_mgmtv2.AwsRds},
+			want: true,
+		},
+		{
+			name: "a non-nil b nil",
+			a:    &apigen_mgmtv2.TenantResourceMetaStore{Type: apigen_mgmtv2.AwsRds},
+			b:    nil,
+			want: true,
+		},
+		{
+			name: "same type",
+			a:    &apigen_mgmtv2.TenantResourceMetaStore{Type: apigen_mgmtv2.AwsRds},
+			b:    &apigen_mgmtv2.TenantResourceMetaStore{Type: apigen_mgmtv2.AwsRds},
+			want: true,
+		},
+		{
+			name: "same type different rwu",
+			a:    &apigen_mgmtv2.TenantResourceMetaStore{Type: apigen_mgmtv2.AwsRds, Rwu: "2"},
+			b:    &apigen_mgmtv2.TenantResourceMetaStore{Type: apigen_mgmtv2.AwsRds, Rwu: ""},
+			want: true,
+		},
+		{
+			name: "different type",
+			a:    &apigen_mgmtv2.TenantResourceMetaStore{Type: apigen_mgmtv2.AwsRds},
+			b:    &apigen_mgmtv2.TenantResourceMetaStore{Type: apigen_mgmtv2.Etcd},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := metaStoreEqual(tt.a, tt.b)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
 func TestClusterCreate_previous_creation_failed(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()


### PR DESCRIPTION
## Summary
- `metaStoreEqual()` had a logic bug: it fell through to `return false` even when both metastore types matched, making it always return `false` when both args were non-nil
- This blocked any cluster update (e.g. version bump) with a spurious "metastore cannot be changed" error
- Fix: replaced the dead `if/return false/return false` pattern with `return a.Type == b.Type`
- Added table-driven unit tests covering nil, same-type, different-rwu, and different-type cases

## Context
Reported by a customer in Slack — upgrading RW engine version from v2.6.3 to v2.7.2 failed with:
```
Error: Cannot update immutable field
metastore cannot be changed, previous: &{... 2 <nil> aws_rds}, updated: &{... <nil> aws_rds}
```

## Test plan
- [x] `TestMetaStoreEqual` — 6 cases all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)